### PR TITLE
Propose an alternative method to simulate input, using pynput

### DIFF
--- a/nerd-dictation
+++ b/nerd-dictation
@@ -707,7 +707,7 @@ def main_begin(
     timeout: float = 0.0,
     punctuate_from_previous_timeout: float = 0.0,
     output: str = "TYPE",
-    input_method: str = "xdotool",
+    input_method: str = "auto",
 ) -> None:
     """
     Initialize audio recording, then full text to speech conversion can take place.
@@ -730,12 +730,13 @@ def main_begin(
 
     if input_method == "pynput":
         try:
-            from pynput.keyboard import Key, Controller
+            from pynput.keyboard import Key, Controller  # type: ignore
+
             keyboard = Controller()
         except ImportError:
             sys.stderr.write("Module 'pynput' is not installed. Defaulting input method to xdotool.")
             input_method = "xdotool"
-    
+
     is_run_on = False
     if punctuate_from_previous_timeout > 0.0:
         age_in_seconds: Optional[float] = None
@@ -1072,11 +1073,13 @@ This creates the directory used to store internal data, so other commands such a
     subparse.add_argument(
         "--simulate-input-method",
         dest="input_method",
-        default="xdotool",
-        choices=("xdotool", "pynput"),
-        help=("Choose the tool to simulate keyboard inputs. Valid choices are:\n"
-            "- ``xdotool`` (default)\n"
-            "- ``pynput``\n"),
+        default="auto",
+        choices=("auto", "pynput"),
+        help=(
+            "Choose the tool to simulate keyboard inputs. Valid choices are:\n"
+            "- ``auto`` uses xdotool with Xorg (default)\n"
+            "- ``pynput``\n"
+        ),
         required=False,
     )
 
@@ -1093,7 +1096,7 @@ This creates the directory used to store internal data, so other commands such a
             timeout=args.timeout,
             punctuate_from_previous_timeout=args.punctuate_from_previous_timeout,
             output=args.output,
-            input_method=args.input_method
+            input_method=args.input_method,
         ),
     )
 

--- a/nerd-dictation
+++ b/nerd-dictation
@@ -707,6 +707,7 @@ def main_begin(
     timeout: float = 0.0,
     punctuate_from_previous_timeout: float = 0.0,
     output: str = "TYPE",
+    input_method: str = "xdotool",
 ) -> None:
     """
     Initialize audio recording, then full text to speech conversion can take place.
@@ -727,6 +728,14 @@ def main_begin(
     if not path_to_cookie:
         path_to_cookie = os.path.join(tempfile.gettempdir(), TEMP_COOKIE_NAME)
 
+    if input_method == "pynput":
+        try:
+            from pynput.keyboard import Key, Controller
+            keyboard = Controller()
+        except ImportError:
+            sys.stderr.write("Module 'pynput' is not installed. Defaulting input method to xdotool.")
+            input_method = "xdotool"
+    
     is_run_on = False
     if punctuate_from_previous_timeout > 0.0:
         age_in_seconds: Optional[float] = None
@@ -824,27 +833,35 @@ def main_begin(
                 if not text_block:
                     pass
                 elif text_block.startswith("\x08"):
-                    cmd = (
-                        "xdotool",
-                        "key",
-                        "--clearmodifiers",
-                        "--delay",
-                        "10",
-                        *(("BackSpace",) * len(text_block)),
-                    )
-                    subprocess.check_output(cmd).decode("utf-8")
+                    if input_method == "pynput":
+                        keyboard.press(Key.backspace)
+                        time.sleep(0.01)
+                        keyboard.release(Key.backspace)
+                    else:
+                        cmd = (
+                            "xdotool",
+                            "key",
+                            "--clearmodifiers",
+                            "--delay",
+                            "10",
+                            *(("BackSpace",) * len(text_block)),
+                        )
+                        subprocess.check_output(cmd).decode("utf-8")
                 else:
-                    cmd = (
-                        "xdotool",
-                        "type",
-                        "--clearmodifiers",
-                        # Use a value higher than twelve so the characters don't get skipped (tsk!).
-                        "--delay",
-                        "10",
-                        "--",
-                        text_block,
-                    )
-                    subprocess.check_output(cmd).decode("utf-8")
+                    if input_method == "pynput":
+                        keyboard.type(text_block)
+                    else:
+                        cmd = (
+                            "xdotool",
+                            "type",
+                            "--clearmodifiers",
+                            # Use a value higher than twelve so the characters don't get skipped (tsk!).
+                            "--delay",
+                            "10",
+                            "--",
+                            text_block,
+                        )
+                        subprocess.check_output(cmd).decode("utf-8")
 
     elif output == "STDOUT":
 
@@ -1052,6 +1069,17 @@ This creates the directory used to store internal data, so other commands such a
         ),
     )
 
+    subparse.add_argument(
+        "--simulate-input-method",
+        dest="input_method",
+        default="xdotool",
+        choices=("xdotool", "pynput"),
+        help=("Choose the tool to simulate keyboard inputs. Valid choices are:\n"
+            "- ``xdotool`` (default)\n"
+            "- ``pynput``\n"),
+        required=False,
+    )
+
     subparse.set_defaults(
         func=lambda args: main_begin(
             path_to_cookie=args.path_to_cookie,
@@ -1065,6 +1093,7 @@ This creates the directory used to store internal data, so other commands such a
             timeout=args.timeout,
             punctuate_from_previous_timeout=args.punctuate_from_previous_timeout,
             output=args.output,
+            input_method=args.input_method
         ),
     )
 


### PR DESCRIPTION
A new option --simulate-input-method is added.
This replaces xdotool and needs pynput as new module.
See #4 