### PR TITLE
[WIP] Add single-word cmd map

### DIFF
--- a/examples/nerd-dictation.py
+++ b/examples/nerd-dictation.py
@@ -1,6 +1,6 @@
 # User configuration file typically located at `~/.config/nerd-dictation/nerd-dictation.py`
 import re
-
+import subprocess
 
 # -----------------------------------------------------------------------------
 # Replace Multiple Words
@@ -14,6 +14,18 @@ TEXT_REPLACE_REGEX = tuple(
     (re.compile(match), replacement)
     for (match, replacement) in TEXT_REPLACE_REGEX
 )
+
+
+# -----------------------------------------------------------------------------
+# Map Single Words To Commands
+
+WORD_CMD_MAP = {
+    "left":     ("xdotool", "click", "--clearmodifiers", "--delay", "10", "1"),
+    "middle":   ("xdotool", "click", "--clearmodifiers", "--delay", "10", "2"),
+    "right":    ("xdotool", "click", "--clearmodifiers", "--delay", "10", "3"),
+    "backward": ("xdotool", "click", "--clearmodifiers", "--delay", "10", "4"),
+    "forward":  ("xdotool", "click", "--clearmodifiers", "--delay", "10", "5"),
+}
 
 
 # -----------------------------------------------------------------------------
@@ -48,6 +60,11 @@ def nerd_dictation_process(text):
 
     for i, w in enumerate(words):
         w_init = w
+        cmd = WORD_CMD_MAP.get(w)
+        if cmd is not None:
+            subprocess.check_output(cmd).decode("utf-8")
+            w = ""
+
         w_test = WORD_REPLACE.get(w)
         if w_test is not None:
             w = w_test


### PR DESCRIPTION
Enable mapping of single words to commands, here mouse-clicks. 

WIP: This requires an option for single-pass word-by-word processing (or similar) in order to enable continuous listening to commands **without emitting them multiple times**, c.f. #16 (at present, the PR will lead to a firework of mouse-clicks...).

Also, to avoid undesired behavior in continuous listening the option to `Add '--commands' command line argument to restrict input to a limited set of commands` (#3) could also be a solution here.

