### PR TITLE
Allow to be run on Windows platform

### DIFF
--- a/nerd-dictation
+++ b/nerd-dictation
@@ -96,7 +96,7 @@ def file_remove_if_exists(filepath: str) -> bool:
 
 
 def enqueue_output(vosk_out, queue):
-    for block in iter(partial(vosk_out.read, 16384), b""):
+    for block in iter(partial(vosk_out.read, 1024), b""):
         queue.put(block)
 
 
@@ -649,7 +649,7 @@ def text_from_vosk_pipe(
             # Skip idling in the event dictation can't keep up with the recording.
             idle_time_curr = time.time()
             idle_time_test = idle_time - (idle_time_curr - idle_time_prev)
-            if idle_time_test > 0.0:
+            if vosk_queue.empty() and  idle_time_test > 0.0:
                 # Prevents excessive processor load.
                 time.sleep(idle_time_test)
                 idle_time_prev = time.time()


### PR DESCRIPTION
I have clients who run on Windows.
Thus I propose this, which consists of:
- using `fmedia` instead `parec`, by detecting that the platform is not `posix`;
- using thread to get sound data instead of non blocking stream, which is a `posix` specific feature;
- using `pynput` keyboard simulation - the option has to be passed.

Thus I got good results for my limited tests on a Windows 8 machine. And it still works on my Linux. 
I used `black` and `mypy` passed.
The value of size block seems important for the reactivity. A big value like 1M give too long interval between results. A lower value like 1k seems to give a too high load. I put 16k which seems a good balance.
https://github.com/papoteur-mga/nerd-dictation/blob/1fb54dc4bd8fc389dbd18001c0185257d60c9fae/nerd-dictation#L99
If this is accepted, some documentation has to be edited.