### PR TITLE
Fix backspace handling with xdotool.

### DIFF
--- a/nerd-dictation
+++ b/nerd-dictation
@@ -59,6 +59,7 @@ USER_CONFIG = "nerd-dictation.py"
 # General Utilities
 #
 
+
 def run_xdotool(subcommand: str, payload: List[str]) -> None:
     cmd = [
         "xdotool",
@@ -528,7 +529,7 @@ def text_from_vosk_pipe(
     vosk_model_dir: str,
     exit_fn: Callable[..., int],
     process_fn: Callable[[str], str],
-    handle_fn: Callable[[str], None],
+    handle_fn: Callable[[str, int], None],
     timeout: float,
     idle_time: float,
     progressive: bool,
@@ -843,8 +844,8 @@ def main_begin(
 
         def handle_fn(text: str, delete_prev_chars: int) -> None:
             if delete_prev_chars:
-                run_xdotool('key', ["BackSpace"] * delete_prev_chars)
-            run_xdotool('type', ["--", text])
+                run_xdotool("key", ["BackSpace"] * delete_prev_chars)
+            run_xdotool("type", ["--", text])
 
     elif output == "STDOUT":
 

--- a/nerd-dictation
+++ b/nerd-dictation
@@ -59,6 +59,14 @@ USER_CONFIG = "nerd-dictation.py"
 # General Utilities
 #
 
+def run_xdotool(subcommand: str, payload: List[str]) -> None:
+    cmd = [
+        "xdotool",
+        subcommand,
+        "--clearmodifiers",
+    ] + payload
+    subprocess.check_output(cmd).decode("utf-8")
+
 
 def touch(filepath: str, time: Optional[float] = None) -> None:
     if os.path.exists(filepath):
@@ -607,8 +615,8 @@ def text_from_vosk_pipe(
                     match = i
                     break
 
-            # Use the ASCII code for back-space (if there is anything to back-space).
-            handle_fn(("\x08" * (len(text_prev) - match)) + text_curr[match:])
+            # Emit text, deleting any previous incorrectly transcribed output
+            handle_fn(text_curr[match:], len(text_prev) - match)
 
             text_prev = text_curr
 
@@ -698,7 +706,8 @@ def text_from_vosk_pipe(
         handle_fn_wrapper(text, False)
 
     if not progressive:
-        handle_fn(process_fn(" ".join(text_list)))
+        # We never arrive here needing deletions
+        handle_fn(process_fn(" ".join(text_list)), 0)
 
     return handled_any
 
@@ -832,39 +841,16 @@ def main_begin(
     #
     if output == "SIMULATE_INPUT":
 
-        def handle_fn(text: str) -> None:
-            import re
-
-            # Back-space character.
-            for text_block in re.split("(\x08)", text):
-                if not text_block:
-                    pass
-                elif text_block.startswith("\x08"):
-                    cmd = (
-                        "xdotool",
-                        "key",
-                        "--clearmodifiers",
-                        "--delay",
-                        "10",
-                        *(("BackSpace",) * len(text_block)),
-                    )
-                    subprocess.check_output(cmd).decode("utf-8")
-                else:
-                    cmd = (
-                        "xdotool",
-                        "type",
-                        "--clearmodifiers",
-                        # Use a value higher than twelve so the characters don't get skipped (tsk!).
-                        "--delay",
-                        "10",
-                        "--",
-                        text_block,
-                    )
-                    subprocess.check_output(cmd).decode("utf-8")
+        def handle_fn(text: str, delete_prev_chars: int) -> None:
+            if delete_prev_chars:
+                run_xdotool('key', ["BackSpace"] * delete_prev_chars)
+            run_xdotool('type', ["--", text])
 
     elif output == "STDOUT":
 
-        def handle_fn(text: str) -> None:
+        def handle_fn(text: str, delete_prev_chars: int) -> None:
+            if delete_prev_chars:
+                sys.stdout.write("\x08" * delete_prev_chars)
             sys.stdout.write(text)
 
     else:


### PR DESCRIPTION
Previous version would issue a separate xdotool command for each backspace
character.   This was very slow and made for a disruptive typing experience.
Use an out-of-band method to signal the need for deletion , which allows us
to invoke xdotool single time for all the deletes.

Also factors out xdotool invocation to reduce duplicate code.  This will help future updates to simulated input code.