### PR TITLE
Fix writing text immediately with --output STDOUT when --continuous is also enabled

### DIFF
--- a/changelog.rst
+++ b/changelog.rst
@@ -3,6 +3,7 @@
 Changelog
 #########
 
+- 2022/04/20: Fix writing text immediately with --output STDOUT when --continuous is also enabled.
 - 2022/04/18: Add ``--input`` option to specify audio recording command, added ``sox`` input.
 - 2022/01/21: Add ``--config`` option to specify a custom configuration file location.
 - 2022/01/21: Correct error reporting an error when evaluating the user configuration fails.

--- a/nerd-dictation
+++ b/nerd-dictation
@@ -1061,6 +1061,7 @@ def main_begin(
             if delete_prev_chars:
                 sys.stdout.write("\x08" * delete_prev_chars)
             sys.stdout.write(text)
+            sys.stdout.flush()
 
     else:
         # Unreachable.
@@ -1349,7 +1350,7 @@ This creates the directory used to store internal data, so other commands such a
             pulse_device_name=args.pulse_device_name,
             sample_rate=args.sample_rate,
             input_method=args.input_method,
-            progressive=not (args.defer_output or args.output == "STDOUT"),
+            progressive=not (args.defer_output or (args.output == "STDOUT" and not args.progressive_continuous)),
             progressive_continuous=args.progressive_continuous,
             full_sentence=args.full_sentence,
             numbers_as_digits=args.numbers_as_digits,


### PR DESCRIPTION
Seems to me that --output STDOUT and --continuous should not defer writing text, this patch fixes that case. 

This allows stdout text to go to a pipe or named pipe immediately.  Backspaces are also passed, when the text is corrected by Vosk.

Here's a simple example of using a named pipe:
```
mkfifo /tmp/nerdpipe
nerd-dictation begin --output STDOUT --continuous >/tmp/nerdpipe
```

In another terminal:
```
while true; do 
    read -n 1000 -t 0.5 input </tmp/nerdpipe
    [[ -n "$input" ]] && echo "nerdpipe says: $input" 
done
```

Demo results:
```
nerdpipe says: hello
nerdpipe says: world
nerdpipe says: this
nerdpipe says: is a
nerdpipe says: longer sentence
nerdpipe says: goodbye
```

I included a flush() on the existing handler, but I also had another version that checked for this condition and only then use flush().  Flushing stdout on every write shouldn't cause much harm, since we can only speak so fast :-)

```
diff --git a/nerd-dictation b/nerd-dictation
index 1d6b626..77e51d4 100755
--- a/nerd-dictation
+++ b/nerd-dictation
@@ -1055,6 +1055,15 @@ def main_begin(
                 run_xdotool("key", ["BackSpace"] * delete_prev_chars)
             run_xdotool("type", ["--", text])

+    elif output == "STDOUT" and progressive:
+
+        def handle_fn(text: str, delete_prev_chars: int) -> None:
+            if delete_prev_chars:
+                sys.stdout.write("\x08" * delete_prev_chars)
+            sys.stdout.write(text)
+            sys.stdout.flush()
+
+  
     elif output == "STDOUT":

         def handle_fn(text: str, delete_prev_chars: int) -> None:
```


