### PR TITLE
Added --verbose flag for "begin"

### DIFF
--- a/nerd-dictation
+++ b/nerd-dictation
@@ -907,6 +907,7 @@ def text_from_vosk_pipe(
     input_method: str,
     pulse_device_name: str = "",
     suspend_on_start: bool = False,
+    verbose: bool = False,
 ) -> bool:
     # Delay some imports until recording has started to avoid minor delays.
     import json
@@ -930,10 +931,16 @@ def text_from_vosk_pipe(
 
     vosk.SetLogLevel(-1)
 
+    # Allow for loading the model to take some time:
+    if verbose:
+        sys.stderr.write("Loading model...\n")
     model = vosk.Model(vosk_model_dir)
     rec = vosk.KaldiRecognizer(model, sample_rate)
-    # 1mb (allow for loading the model to take some time).
-    block_size = 104_8576
+    if verbose:
+        sys.stderr.write("Model loaded.\n")
+
+    # 1mb
+    block_size = 1_048_576
 
     use_timeout = timeout != 0.0
     if use_timeout:
@@ -1053,7 +1060,10 @@ def text_from_vosk_pipe(
 
         # Clear the buffer:
         handle_fn_suspended()
-        print("Suspended.\n")
+
+        nonlocal verbose
+        if verbose:
+            sys.stderr.write("Recording suspended.\n")
 
         # Close the recording process.
         os.kill(ps.pid, signal.SIGINT)
@@ -1063,7 +1073,9 @@ def text_from_vosk_pipe(
         nonlocal stdout
 
         # Resume reading from the recording process.
-        print("Recording.\n")
+        nonlocal verbose
+        if verbose:
+            sys.stderr.write("Recording.\n")
 
         ps, stdout = recording_proc_start()
 
@@ -1193,6 +1205,7 @@ def main_begin(
     output: str = "TYPE",
     simulate_input_tool: str = "XDOTOOL",
     suspend_on_start: bool = False,
+    verbose: bool = False,
 ) -> None:
     """
     Initialize audio recording, then full text to speech conversion can take place.
@@ -1351,6 +1364,7 @@ def main_begin(
         process_fn=process_fn,
         handle_fn=handle_fn,
         suspend_on_start=suspend_on_start,
+        verbose=verbose,
     )
 
     if not found_any:
@@ -1691,6 +1705,16 @@ def argparse_create_begin(subparsers: "argparse._SubParsersAction[argparse.Argum
         ),
         required=False,
     )
+
+    subparse.add_argument(
+        "--verbose",
+        dest="verbose",
+        default=False,
+        action="store_true",
+        help=("Verbose output"),
+        required=False,
+    )
+
     subparse.add_argument(
         "-",
         dest="rest",
@@ -1724,6 +1748,7 @@ def argparse_create_begin(subparsers: "argparse._SubParsersAction[argparse.Argum
             output=args.output,
             simulate_input_tool=args.simulate_input_tool,
             suspend_on_start=args.suspend_on_start,
+            verbose=args.verbose,
         ),
     )
 

--- a/nerd-dictation
+++ b/nerd-dictation
@@ -907,7 +907,7 @@ def text_from_vosk_pipe(
     input_method: str,
     pulse_device_name: str = "",
     suspend_on_start: bool = False,
-    verbose: bool = False,
+    verbose: int = 0,
 ) -> bool:
     # Delay some imports until recording has started to avoid minor delays.
     import json
@@ -932,11 +932,11 @@ def text_from_vosk_pipe(
     vosk.SetLogLevel(-1)
 
     # Allow for loading the model to take some time:
-    if verbose:
+    if verbose >= 1:
         sys.stderr.write("Loading model...\n")
     model = vosk.Model(vosk_model_dir)
     rec = vosk.KaldiRecognizer(model, sample_rate)
-    if verbose:
+    if verbose >= 1:
         sys.stderr.write("Model loaded.\n")
 
     # 1mb
@@ -1062,7 +1062,7 @@ def text_from_vosk_pipe(
         handle_fn_suspended()
 
         nonlocal verbose
-        if verbose:
+        if verbose >= 1:
             sys.stderr.write("Recording suspended.\n")
 
         # Close the recording process.
@@ -1074,7 +1074,7 @@ def text_from_vosk_pipe(
 
         # Resume reading from the recording process.
         nonlocal verbose
-        if verbose:
+        if verbose >= 1:
             sys.stderr.write("Recording.\n")
 
         ps, stdout = recording_proc_start()
@@ -1205,7 +1205,7 @@ def main_begin(
     output: str = "TYPE",
     simulate_input_tool: str = "XDOTOOL",
     suspend_on_start: bool = False,
-    verbose: bool = False,
+    verbose: int = 0,
 ) -> None:
     """
     Initialize audio recording, then full text to speech conversion can take place.
@@ -1382,7 +1382,7 @@ def main_end(
         path_to_cookie = os.path.join(tempfile.gettempdir(), TEMP_COOKIE_NAME)
 
     # Resume (does nothing if not suspended), so suspending doesn't prevent the cancel operation.
-    main_suspend(path_to_cookie=path_to_cookie, suspend=False, verbose=False)
+    main_suspend(path_to_cookie=path_to_cookie, suspend=False, verbose=0)
 
     touch(path_to_cookie)
 
@@ -1395,7 +1395,7 @@ def main_cancel(
         path_to_cookie = os.path.join(tempfile.gettempdir(), TEMP_COOKIE_NAME)
 
     # Resume (does nothing if not suspended), so suspending doesn't prevent the cancel operation.
-    main_suspend(path_to_cookie=path_to_cookie, suspend=False, verbose=False)
+    main_suspend(path_to_cookie=path_to_cookie, suspend=False, verbose=0)
 
     file_remove_if_exists(path_to_cookie)
 
@@ -1404,7 +1404,7 @@ def main_suspend(
     *,
     path_to_cookie: str = "",
     suspend: bool,
-    verbose: bool,
+    verbose: int,
 ) -> None:
     import signal
 
@@ -1412,7 +1412,7 @@ def main_suspend(
         path_to_cookie = os.path.join(tempfile.gettempdir(), TEMP_COOKIE_NAME)
 
     if not os.path.exists(path_to_cookie):
-        if verbose:
+        if verbose >= 1:
             sys.stderr.write("No running nerd-dictation cookie found at: {:s}, abort!\n".format(path_to_cookie))
         return
 
@@ -1421,7 +1421,7 @@ def main_suspend(
     try:
         pid = int(data)
     except Exception as ex:
-        if verbose:
+        if verbose >= 1:
             sys.stderr.write("Failed to read PID with error {!r}, abort!\n".format(ex))
         return
 
@@ -1709,8 +1709,8 @@ def argparse_create_begin(subparsers: "argparse._SubParsersAction[argparse.Argum
     subparse.add_argument(
         "--verbose",
         dest="verbose",
-        default=False,
-        action="store_true",
+        default=0,
+        type=int,
         help=("Verbose output"),
         required=False,
     )
@@ -1808,7 +1808,7 @@ def argparse_create_suspend(subparsers: "argparse._SubParsersAction[argparse.Arg
         func=lambda args: main_suspend(
             path_to_cookie=args.path_to_cookie,
             suspend=True,
-            verbose=True,
+            verbose=1,
         ),
     )
 
@@ -1832,7 +1832,7 @@ def argparse_create_resume(subparsers: "argparse._SubParsersAction[argparse.Argu
         func=lambda args: main_suspend(
             path_to_cookie=args.path_to_cookie,
             suspend=False,
-            verbose=True,
+            verbose=1,
         ),
     )
 


### PR DESCRIPTION
Moved suspend/resume notices to stderr and use --verbose flag

Added Model loading/loaded prints if --verbose is set.  This is useful for large datsets because it takes a while to load.  Then you can when it is ready to take dictation.

Signed-off-by: Eric Wheeler <vosk-git@z.ewheeler.org>