### PR TITLE
Add SIGHUP support: reload the user config without restart

### DIFF
--- a/nerd-dictation
+++ b/nerd-dictation
@@ -300,7 +300,7 @@ def calc_user_config_path(rest: Optional[str]) -> str:
 
 
 def user_config_as_module_or_none(
-    config_override: Optional[str],
+    config_override: Optional[str], prev_user_config: Optional[ModuleType]
 ) -> Optional[ModuleType]:
 
     # Explicitly ask for no configuration.
@@ -318,7 +318,13 @@ def user_config_as_module_or_none(
         user_config = execfile(user_config_path)
     except Exception as ex:
         sys.stderr.write('Failed to run "{:s}" with error: {:s}\n'.format(user_config_path, str(ex)))
-        sys.exit(1)
+        if not prev_user_config:
+            # Exit only if this is the first time the config is loaded
+            sys.exit(1)
+        else:
+            # The user has been warned about their syntax error, so keep the current config
+            sys.stderr.write("Reload failed, continuing with previous configuration.\n")
+            user_config = prev_user_config
 
     return user_config
 
@@ -1096,6 +1102,12 @@ def text_from_vosk_pipe(
         suspend = False
         do_suspend_resume()
 
+    def handle_sig_reload_from_hup(_signum: int, _frame: Optional[FrameType]) -> None:
+        if verbose >= 1:
+            sys.stderr.write("Reload.\n")
+        process_fn("")
+        return
+
     import signal
 
     # Suspend resume from separate signals.
@@ -1106,6 +1118,8 @@ def text_from_vosk_pipe(
     signal.signal(signal.SIGTSTP, handle_sig_suspend_from_usr1)
 
     signal.signal(signal.SIGCONT, handle_sig_resume_from_cont)
+
+    signal.signal(signal.SIGHUP, handle_sig_reload_from_hup)
 
     if suspend:
         # Use when Py3.6 compatibility is dropped.
@@ -1288,8 +1302,13 @@ def main_begin(
         #
         # Load the user configuration (when found).
         #
-        if process_fn_is_first:
-            user_config = user_config_as_module_or_none(config_override=config_override)
+        # text=="" indicates that user_config should be reloaded (SIGHUP)
+        #
+        if process_fn_is_first or text == "":
+            user_config = user_config_as_module_or_none(config_override=config_override, prev_user_config=user_config)
+
+        if not text:
+            return ""
 
         #
         # Simple text post processing and capitalization.


### PR DESCRIPTION
Reloads with syntax errors do not crash the running process.  See commit messages for detail.