### PR TITLE
add pw-cat input

### DIFF
--- a/nerd-dictation
+++ b/nerd-dictation
@@ -901,6 +901,16 @@ def recording_proc_with_non_blocking_stdout(
             "-L",
             "-",
         )
+    elif input_method == "PW-CAT":
+        cmd = (
+            "pw-cat",
+            "--record",
+            "--format=s16",
+            "--rate",
+            str(sample_rate),
+            "--channels=1",
+            "-",
+        )
     else:
         sys.stderr.write("--input %r not supported.\n" % input_method)
         sys.exit(1)
@@ -1756,7 +1766,7 @@ def argparse_create_begin(subparsers: "argparse._SubParsersAction[argparse.Argum
         default="PAREC",
         type=str,
         metavar="INPUT_METHOD",
-        choices=("PAREC", "SOX"),
+        choices=("PAREC", "SOX", "PW-CAT"),
         help=(
             "Specify input method to be used for audio recording. Valid methods: PAREC, SOX\n"
             "\n"
@@ -1764,6 +1774,7 @@ def argparse_create_begin(subparsers: "argparse._SubParsersAction[argparse.Argum
             "  See --pulse-device-name option to use a specific pulse-audio device.\n"
             "- ``SOX`` (external command)\n"
             "  For help on setting up sox, see ``readme-sox.rst`` in the nerd-dictation repository.\n"
+            "- ``PW-CAT`` (external command)\n"
         ),
         required=False,
     )

--- a/readme.rst
+++ b/readme.rst
@@ -84,6 +84,7 @@ You may select one of the following tools.
 
 - ``parec`` command for recording from pulse-audio.
 - ``sox`` command as alternative, see the guide: `Using sox with nerd-dictation <readme-sox.rst>`_.
+- ``pw-cat`` command for recording from pipewire.
 
 
 Input Simulation Utilities
@@ -265,12 +266,13 @@ options:
                         from being turned into "no 1".
   --numbers-no-suffix   Suppress number suffixes when --numbers-as-digits is specified.
                         For example, this will prevent "first" from becoming "1st".
-  --input INPUT_METHOD  Specify input method to be used for audio recording. Valid methods: PAREC, SOX
+  --input INPUT_METHOD  Specify input method to be used for audio recording. Valid methods: PAREC, SOX, PW-CAT.
 
                         - ``PAREC`` (external command, default)
                           See --pulse-device-name option to use a specific pulse-audio device.
                         - ``SOX`` (external command)
                           For help on setting up sox, see ``readme-sox.rst`` in the nerd-dictation repository.
+                        - ``PW-CAT`` (external command)
   --output OUTPUT_METHOD
                         Method used to at put the result of speech to text.
 


### PR DESCRIPTION
This pull request adds support for the `pw-cat` input method for audio recording which is the standard on pipewire.